### PR TITLE
[BUGFIX] fix missing info-box in page view #5

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,3 +1,6 @@
+imports:
+  - { resource: 'Services/EventListener.yaml' }
+
 services:
   _defaults:
     autowire: true
@@ -6,6 +9,7 @@ services:
 
   T3\PwComments\:
     resource: '../Classes/*'
+    exclude: '../Classes/{Event/Listener}'
 
   T3\PwComments\Hooks\ProcessDatamap:
     public: true
@@ -38,6 +42,11 @@ services:
     arguments:
       $queryBuilder: '@qb.comment'
       $extConfig: '@pw_comments.extension_config'
+
+  TYPO3\CMS\Core\Localization\LanguageService:
+    factory:
+      - '@TYPO3\CMS\Core\Localization\LanguageServiceFactory'
+      - 'create'
 
   T3\PwComments\Update\MigratePluginsUpgradeWizard:
     arguments:

--- a/Configuration/Services/EventListener.yaml
+++ b/Configuration/Services/EventListener.yaml
@@ -1,0 +1,13 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  T3\PwComments\Event\Listener\:
+    resource: '../Classes/Event/Listener/*'
+
+  T3\PwComments\Event\Listener\ModifyPageLayoutEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'pw_comments/modify-page-module-content'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -106,13 +106,4 @@ if (!defined('TYPO3')) {
     // After save hook
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] =
         ProcessDatamap::class;
-
-    $extensionConfig = GeneralUtility::makeInstance(
-        ExtensionConfiguration::class
-    )->get('pw_comments');
-    if (!isset($extensionConfig['pageModuleNotice']) || $extensionConfig['pageModuleNotice'] !== '0') {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][PageLayoutController::class] = [
-            'className' => \T3\PwComments\XClass\PageLayoutController::class,
-        ];
-    }
 })('pw_comments');


### PR DESCRIPTION
- The method from PageLayoutController overwritten via XCLASS has been removed with TYPO3 v11. An event listener is now being used as a modern replacement.