### PR TITLE
Return redirect responses instead of 'false'

### DIFF
--- a/Classes/Controller/CommentController.php
+++ b/Classes/Controller/CommentController.php
@@ -223,12 +223,10 @@ class CommentController extends ActionController
         if (isset($this->settings['hiddenFieldSpamProtection']) && $this->settings['hiddenFieldSpamProtection']
             && $this->request->hasArgument($this->settings['hiddenFieldName'])
             && $this->request->getArgument($this->settings['hiddenFieldName'])) {
-            $this->redirectToUri($this->buildUriByUid($this->pageUid) . '#' . $this->settings['writeCommentAnchor']);
-            return false;
+            return $this->redirectToUri($this->buildUriByUid($this->pageUid) . '#' . $this->settings['writeCommentAnchor']);
         }
         if ($newComment === null) {
-            $this->redirectToUri($this->buildUriByUid($this->pageUid));
-            return false;
+            return $this->redirectToUri($this->buildUriByUid($this->pageUid));
         }
         $this->createAuthorIdent();
 


### PR DESCRIPTION
Properly return redirect responses from `CommentController` instead of returning `false`.

You can test this by manually opening the comment form action with your browser as a GET request. Currently, version 6.0.0 of pw_comments will throw an error, because an action controller must not `return false`.