### PR TITLE
fix #9

### DIFF
--- a/Classes/Domain/Model/Comment.php
+++ b/Classes/Domain/Model/Comment.php
@@ -260,14 +260,9 @@ class Comment extends AbstractEntity
      *
      * @return string
      */
-    public function getCommentAuthorMailAddress()
+    public function getCommentAuthorMailAddress(): string
     {
-        $authorMail = $this->getAuthorMail();
-        if ($this->getAuthor() !== null) {
-            $authorMail = $this->getAuthor()->getEmail();
-        }
-
-        return $authorMail;
+        return $this->getAuthor()?->getEmail() ?? $this->getAuthorMail();
     }
 
     /**

--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -7,4 +7,16 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class FrontendUser extends AbstractEntity
 {
+    protected string $email = '';
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
 }


### PR DESCRIPTION
Fixes undefined method error when logged in users try to post a new comment. [Since TYPO3 v11](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94654-GenericExtbaseDomainClasses.html) the generic FrontendUser-model was removed and has to be implemented from scratch.