### PR TITLE
[TASK] Implicitly allow params to be null for php8.4

### DIFF
--- a/Classes/Controller/CommentController.php
+++ b/Classes/Controller/CommentController.php
@@ -171,7 +171,7 @@ class CommentController extends ActionController implements LoggerAwareInterface
      * @return void
      */
     #[IgnoreValidation(['value' => 'commentToReplyTo'])]
-    public function indexAction(Comment $commentToReplyTo = null): ResponseInterface
+    public function indexAction(?Comment $commentToReplyTo = null): ResponseInterface
     {
         if (isset($this->settings['invertCommentSorting']) && $this->settings['invertCommentSorting']) {
             $this->commentRepository->setInvertCommentSorting(true);
@@ -222,7 +222,7 @@ class CommentController extends ActionController implements LoggerAwareInterface
      * Create action
      */
     #[Validate(['validator' => CommentValidator::class, 'param' => 'newComment'])]
-    public function createAction(Comment $newComment = null): ResponseInterface
+    public function createAction(?Comment $newComment = null): ResponseInterface
     {
         // Hidden field Spam-Protection
         if (isset($this->settings['hiddenFieldSpamProtection']) && $this->settings['hiddenFieldSpamProtection']
@@ -272,7 +272,7 @@ class CommentController extends ActionController implements LoggerAwareInterface
                     $this->settings
                 );
                 $moderationResult = $moderationService->moderateComment($newComment);
-                
+
                 if ($moderationResult->isViolation()) {
                     $aiModerationViolation = true;
                     $aiModerationReason = $moderationResult->getFormattedReason();
@@ -290,7 +290,7 @@ class CommentController extends ActionController implements LoggerAwareInterface
                     // Set error status and continue with normal moderation flow
                     $newComment->setAiModerationStatus('error');
                     $newComment->setAiModerationReason('AI moderation failed: ' . $e->getMessage());
-                    
+
                     // Log the error for administrators
                     $this->logger->error('AI moderation service failed', [
                         'exception' => $e,
@@ -309,12 +309,12 @@ class CommentController extends ActionController implements LoggerAwareInterface
 
         // Modify comment if moderation is active or AI flagged content
         $moderationActive = (isset($this->settings['moderateNewComments']) && $this->settings['moderateNewComments']) || $aiModerationViolation;
-        
+
         if ($moderationActive) {
             $newComment->setHidden(true);
             if ($aiModerationViolation) {
                 $this->addFlashMessage(
-                    LocalizationUtility::translate('tx_pwcomments.aiModerationNotice', 'PwComments', [$aiModerationReason]) ?? 
+                    LocalizationUtility::translate('tx_pwcomments.aiModerationNotice', 'PwComments', [$aiModerationReason]) ??
                     'Your comment has been flagged by our content moderation system: ' . $aiModerationReason
                 );
             } else {
@@ -370,7 +370,7 @@ class CommentController extends ActionController implements LoggerAwareInterface
      */
     #[IgnoreValidation(['value' => 'newComment'])]
     #[IgnoreValidation(['value' => 'commentToReplyTo'])]
-    public function newAction(Comment $newComment = null, Comment $commentToReplyTo = null): ResponseInterface
+    public function newAction(?Comment $newComment = null, ?Comment $commentToReplyTo = null): ResponseInterface
     {
         if ($newComment !== null) {
             $this->view->assign('newComment', $newComment);

--- a/Classes/Utility/Mail.php
+++ b/Classes/Utility/Mail.php
@@ -78,7 +78,7 @@ class Mail
      *
      * @return void
      */
-    public function setView(ViewInterface|FluidViewAdapter $view = null): void
+    public function setView(null|ViewInterface|FluidViewAdapter $view = null): void
     {
         if (!$view) {
             $view = GeneralUtility::makeInstance(ViewFactoryInterface::class)->create(new ViewFactoryData());

--- a/Classes/Utility/Settings.php
+++ b/Classes/Utility/Settings.php
@@ -30,7 +30,7 @@ class Settings extends AbstractEncryptionUtility
      * @param bool $makeSettingsRenderable If TRUE settings are renderable
      * @return array the configuration array with the rendered typoscript
      */
-    public static function renderConfigurationArray(array $settings, $makeSettingsRenderable = false, ServerRequestInterface $request = null)
+    public static function renderConfigurationArray(array $settings, $makeSettingsRenderable = false, ?ServerRequestInterface $request = null)
     {
         /** @var ContentObjectRenderer|null $contentObject */
         $contentObject = $request?->getAttribute('currentContentObject');


### PR DESCRIPTION
When clearing the TYPO3 cache you get a lot of deprecation warnings (php8.4, TYPO3 13.4.24, pw_comments 7.0.0)

PHP Deprecated:  T3\PwComments\Controller\CommentController::indexAction(): Implicitly marking parameter $commentToReplyTo as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 174

Deprecated: T3\PwComments\Controller\CommentController::indexAction(): Implicitly marking parameter $commentToReplyTo as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 174
PHP Deprecated:  T3\PwComments\Controller\CommentController::createAction(): Implicitly marking parameter $newComment as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 225

Deprecated: T3\PwComments\Controller\CommentController::createAction(): Implicitly marking parameter $newComment as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 225
PHP Deprecated:  T3\PwComments\Controller\CommentController::newAction(): Implicitly marking parameter $newComment as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 373

Deprecated: T3\PwComments\Controller\CommentController::newAction(): Implicitly marking parameter $newComment as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 373
PHP Deprecated:  T3\PwComments\Controller\CommentController::newAction(): Implicitly marking parameter $commentToReplyTo as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 373

Deprecated: T3\PwComments\Controller\CommentController::newAction(): Implicitly marking parameter $commentToReplyTo as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Controller/CommentController.php on line 373
PHP Deprecated:  T3\PwComments\Utility\Mail::setView(): Implicitly marking parameter $view as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Utility/Mail.php on line 81

Deprecated: T3\PwComments\Utility\Mail::setView(): Implicitly marking parameter $view as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Utility/Mail.php on line 81
PHP Deprecated:  T3\PwComments\Utility\Settings::renderConfigurationArray(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Utility/Settings.php on line 33

Deprecated: T3\PwComments\Utility\Settings::renderConfigurationArray(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/teamneusta/pw_comments/Classes/Utility/Settings.php on line 33