### PR TITLE
[BUGFIX] Preserve URL parameters in generated comment links

### DIFF
--- a/Classes/Controller/CommentController.php
+++ b/Classes/Controller/CommentController.php
@@ -602,22 +602,23 @@ class CommentController extends ActionController implements LoggerAwareInterface
         $excludeCommentRelatedParameter = false,
         array $arguments = []
     ): string {
+        $namespace = 'tx_pwcomments_' . strtolower($this->request->getPluginName());
         $excludeFromQueryString = [
-            'tx_pwcomments_pi1[action]',
-            'tx_pwcomments_pi1[controller]',
-            'tx_pwcomments_pi1[hash]',
+            $namespace . '[action]',
+            $namespace . '[controller]',
+            $namespace . '[hash]',
             'cHash'
         ];
 
         if ($excludeCommentRelatedParameter === true) {
-            $excludeFromQueryString[] = 'tx_pwcomments_pi1[comment]';
-            $excludeFromQueryString[] = 'tx_pwcomments_pi1[commentToReplyTo]';
+            $excludeFromQueryString[] = $namespace . '[comment]';
+            $excludeFromQueryString[] = $namespace . '[commentToReplyTo]';
         }
 
         $uri = $this->uriBuilder
                 ->reset()
                 ->setTargetPageUid($uid)
-                ->setAddQueryString(true)
+                ->setAddQueryString('untrusted')
                 ->setArgumentsToBeExcludedFromQueryString($excludeFromQueryString)
                 ->setArguments($arguments)
                 ->build();

--- a/Resources/Private/Partials/Comment.html
+++ b/Resources/Private/Partials/Comment.html
@@ -48,12 +48,12 @@
 			<f:if condition="{settings.enableRepliesToComments} == 1">
 				<f:if condition="{comment.parentComment}">
 					<f:then>
-						<f:link.action class="reply" action="new" arguments="{commentToReplyTo:comment.parentComment}" section="{settings.writeCommentAnchor}" addQueryString="true">
+						<f:link.action class="reply" action="new" arguments="{commentToReplyTo:comment.parentComment}" section="{settings.writeCommentAnchor}" addQueryString="untrusted">
 							<f:translate key="tx_pwcomments.reply" />
 						</f:link.action>
 					</f:then>
 					<f:else>
-						<f:link.action class="reply" action="new" arguments="{commentToReplyTo:comment}" section="{settings.writeCommentAnchor}" addQueryString="true">
+						<f:link.action class="reply" action="new" arguments="{commentToReplyTo:comment}" section="{settings.writeCommentAnchor}" addQueryString="untrusted">
 							<f:translate key="tx_pwcomments.reply" />
 						</f:link.action>
 					</f:else>

--- a/Resources/Private/Partials/Comment/Voting.html
+++ b/Resources/Private/Partials/Comment/Voting.html
@@ -3,6 +3,6 @@
 	<f:if condition="{comment.voteSum} > 0">+</f:if>{comment.voteSum}
 </span>
 <f:if condition="{settings.hideVoteButtons} == 0">
-	<f:link.action action="upvote" arguments="{comment:comment}" addQueryString="true" class="upvote{f:if(condition:'{pw:inArray(subject:\'{upvotedCommentUids}\', needle:\'{comment.uid}\')}', then:' voted')}" section="{settings.commentAnchorPrefix}{comment.uid}"><f:translate key="tx_pwcomments.votes.upvote" /></f:link.action>
-	<f:link.action action="downvote" arguments="{comment:comment}" addQueryString="true" class="downvote{f:if(condition:'{pw:inArray(subject:\'{downvotedCommentUids}\', needle:\'{comment.uid}\')}', then:' voted')}" section="{settings.commentAnchorPrefix}{comment.uid}"><f:translate key="tx_pwcomments.votes.downvote" /></f:link.action>
+	<f:link.action action="upvote" arguments="{comment:comment}" addQueryString="untrusted" class="upvote{f:if(condition:'{pw:inArray(subject:\'{upvotedCommentUids}\', needle:\'{comment.uid}\')}', then:' voted')}" section="{settings.commentAnchorPrefix}{comment.uid}"><f:translate key="tx_pwcomments.votes.upvote" /></f:link.action>
+	<f:link.action action="downvote" arguments="{comment:comment}" addQueryString="untrusted" class="downvote{f:if(condition:'{pw:inArray(subject:\'{downvotedCommentUids}\', needle:\'{comment.uid}\')}', then:' voted')}" section="{settings.commentAnchorPrefix}{comment.uid}"><f:translate key="tx_pwcomments.votes.downvote" /></f:link.action>
 </f:if>

--- a/Resources/Private/Templates/Comment/New.html
+++ b/Resources/Private/Templates/Comment/New.html
@@ -12,7 +12,7 @@
 		</f:else>
 	</f:if></h3>
 
-	<f:form name="newComment" object="{newComment}" action="create" section="{settings.writeCommentAnchor}" addQueryString="true">
+	<f:form name="newComment" object="{newComment}" action="create" section="{settings.writeCommentAnchor}" addQueryString="untrusted">
 		<div class="typo3-messages">
 			<a name="{settings.successfulAnchor}"></a>
 			<f:flashMessages />

--- a/Resources/Private/Templates/MailNotification/mail.html
+++ b/Resources/Private/Templates/MailNotification/mail.html
@@ -6,7 +6,7 @@
 <f:if condition="{settings.moderateNewComments}">
 <f:translate key="tx_pwcomments.notificationMail.linkToApproval" />
 <f:format.raw><f:uri.action action="confirmComment" controller="Comment" arguments="{comment:'{comment}', hash:'{hash}'}"
-              addQueryString="true" argumentsToBeExcludedFromQueryString="{0:'id', 1:'chash', 2:'tx_pwcomments_pi1'}" absolute="1"
+              addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0:'id', 1:'chash', 2:'tx_pwcomments_new'}" absolute="1"
               section="{settings.commentAnchorPrefix}{comment.uid}" /></f:format.raw>
 </f:if>
 ---------------------------------------------------


### PR DESCRIPTION
## Summary

When pw_comments is rendered on a foreign record (e.g. a news detail page), generated links dropped the host record's GET parameters (e.g. `tx_news_pi1[news]`), sending users back to the default view instead of the record they were commenting on.

Root cause is a TYPO3 v12+/v13 behavior change: arbitrary ("untrusted") query parameters are only carried over when `addQueryString` is set to `"untrusted"`. Plain `"true"` / `setAddQueryString(true)` no longer includes them (deprecated v12, removed v13).

## Changes

- `CommentController::buildUriByUid()`: use `setAddQueryString('untrusted')` and derive the excluded-parameter namespace from the current plugin name (`tx_pwcomments_<plugin>`), replacing the stale no-op `tx_pwcomments_pi1` prefix.
- `Voting.html`, `New.html` (`<f:form>`), `Comment.html` (reply links): `addQueryString="true"` -> `"untrusted"`.
- `mail.html`: `addQueryString="true"` -> `"untrusted"` and fix the stale `tx_pwcomments_pi1` exclusion -> `tx_pwcomments_new`.

The original report's `Partials/PageLink.html` suggestion no longer applies — that link is built in PHP via `buildUriByUid()`.

Fixes #40