### PR TITLE
fix: add missing FrontendUser properties

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -9,6 +9,12 @@ class FrontendUser extends AbstractEntity
 {
     protected string $email = '';
 
+    protected string $username = '';
+
+    protected string $name = '';
+
+    protected string $title = '';
+
     public function getEmail(): string
     {
         return $this->email;
@@ -17,6 +23,36 @@ class FrontendUser extends AbstractEntity
     public function setEmail(string $email): void
     {
         $this->email = $email;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
     }
 
 }

--- a/Tests/Fixtures/Database/tx_pwcomments_domain_model_comment.csv
+++ b/Tests/Fixtures/Database/tx_pwcomments_domain_model_comment.csv
@@ -1,6 +1,7 @@
 tx_pwcomments_domain_model_comment
-,uid,pid,orig_pid,entry_uid,message,author_name,author_mail,author_ident,hidden,crdate
-,1,1,1,0,"Test comment 1","John Doe","john@example.com","test-ident-1",0,1609459200
-,2,1,1,0,"Test comment 2","Jane Smith","jane@example.com","test-ident-2",0,1609545600
-,3,1,2,123,"Comment on news article","News Reader","reader@example.com","test-ident-3",0,1609632000
-,4,1,1,0,"Pending comment awaiting confirmation","Pending Author","pending@example.com","test-ident-4",1,1609718400
+,uid,pid,orig_pid,entry_uid,author,message,author_name,author_mail,author_ident,hidden,crdate
+,1,1,1,0,0,"Test comment 1","John Doe","john@example.com","test-ident-1",0,1609459200
+,2,1,1,0,0,"Test comment 2","Jane Smith","jane@example.com","test-ident-2",0,1609545600
+,3,1,2,123,0,"Comment on news article","News Reader","reader@example.com","test-ident-3",0,1609632000
+,4,1,1,0,0,"Pending comment awaiting confirmation","Pending Author","pending@example.com","test-ident-4",1,1609718400
+,5,1,1,0,1,"Comment by registered user","","","1",0,1609804800

--- a/Tests/Functional/Controller/CommentControllerTest.php
+++ b/Tests/Functional/Controller/CommentControllerTest.php
@@ -53,6 +53,20 @@ final class CommentControllerTest extends FunctionalTestCase
         self::assertStringContainsString('Test comment 2', $body);
     }
 
+    /**
+     * Issue #41: comments by a registered frontend user render the user's
+     * username (via {comment.author.username}). This only works once the
+     * FrontendUser model exposes the username property, otherwise the author
+     * name stayed blank.
+     */
+    #[Test]
+    public function indexActionRendersRegisteredUserUsername(): void
+    {
+        $body = $this->renderPage();
+
+        self::assertStringContainsString('testuser', $body);
+    }
+
     #[Test]
     public function votingLinksArePresentForComments(): void
     {


### PR DESCRIPTION
## Summary
- The comment partial (`Resources/Private/Partials/Comment.html`) and the three mail notification templates reference `{comment.author.username}`, but the `FrontendUser` model only defined `email` — so registered users' names rendered blank.
- Adds `username`, `name` and `title` properties (with getters/setters) to `FrontendUser`. The model maps to `fe_users` via Extbase's default camelCase column mapping, so these populate automatically with no DB/TCA changes.
- `name` and `title` were also requested in the issue for use in custom templates.

fixes #41