### PR TITLE
ci: run unit and functional tests on PRs and pushes to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.2'
+          - '8.3'
+          - '8.4'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: intl, mbstring, xml, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --no-progress --prefer-dist
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit -c Build/phpunit.xml --testsuite "Unit Tests" --no-coverage
+
+  functional:
+    name: Functional tests (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.2'
+          - '8.3'
+          - '8.4'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: intl, mbstring, xml, zip, pdo_sqlite, sqlite3
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --no-progress --prefer-dist
+
+      - name: Run functional tests
+        run: vendor/bin/phpunit -c Build/phpunit.functional.xml --testsuite "Functional Tests"


### PR DESCRIPTION
## Summary
- Add a `Tests` GitHub Actions workflow that runs the PHPUnit **unit** and **functional** suites on every pull request and on pushes to `main`.
- Both suites run across a PHP **8.2 / 8.3 / 8.4** matrix (the extension's supported range under TYPO3 v13).
- Functional tests use the SQLite driver (`pdo_sqlite`), so no MySQL service container is needed.
- Dependencies are installed with `composer update` since the repo does not commit `composer.lock`; this also regenerates `public/index.php` via the TYPO3 composer installer, which the functional testing framework requires.