### PR TITLE
fix: limit Crowdin source to English base language files

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
-  - source: /Resources/Private/Language/
+  - source: /Resources/Private/Language/locallang*.xlf
     translation: /%original_path%/%locale_with_underscore%.%original_file_name%


### PR DESCRIPTION
## Summary

The `source` entry in `crowdin.yml` pointed at the whole `Resources/Private/Language/` directory, so Crowdin treated every file there as a translation source — including already-translated files (e.g. `de_DE.locallang.xlf`) and `badwords.txt`. When an old German base file (`de.locallang.xlf`) was present, this produced orphaned, untranslated placeholder files named `{locale}.de.locallang.xlf` for every language.

This restricts the source glob to `locallang*.xlf`, so only the English base files (`locallang.xlf`, `locallang_db.xlf`, `locallang_constants.xlf`) are used as sources. Locale-prefixed translations and badwords files are no longer mistaken for sources, and translations continue to generate under the standard `{locale}.locallang.xlf` naming.