### PR TITLE
feat: support PHP 8.2 to 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout
@@ -49,6 +50,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -26,8 +26,8 @@ pw_comments is an extension for TYPO3 CMS which adds the possibility to post com
 
 Requirements of pw_comments
 ---------------------------
-- PHP: ``^8.1``
-- TYPO3 CMS: ``^12.4``
+- PHP: ``^8.2``
+- TYPO3 CMS: ``^13.4``
 
 .. _features:
 

--- a/Tests/Unit/Controller/CommentControllerTest.php
+++ b/Tests/Unit/Controller/CommentControllerTest.php
@@ -440,7 +440,6 @@ final class CommentControllerTest extends TestCase
     {
         $reflection = new \ReflectionClass($this->controller);
         $property = $reflection->getProperty($propertyName);
-        $property->setAccessible(true);
         $property->setValue($this->controller, $value);
     }
 
@@ -554,7 +553,6 @@ final class CommentControllerTest extends TestCase
         $pageInfo = new PageInformation();
         $pageInfoReflection = new \ReflectionClass($pageInfo);
         $idProperty = $pageInfoReflection->getProperty('id');
-        $idProperty->setAccessible(true);
         $idProperty->setValue($pageInfo, $pageUid);
 
         $serverRequest = new ServerRequest();

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,6 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '7.0.0',
     'constraints' => [
         'depends' => [
+            'php' => '8.2.0-8.5.99',
             'typo3' => '13.4.0-13.4.99'
         ],
         'conflicts' => [


### PR DESCRIPTION
## Summary
- Add PHP `8.5` to the unit and functional test matrices in `.github/workflows/tests.yml` (now covers 8.2, 8.3, 8.4, 8.5).
- Declare the supported PHP range `8.2.0-8.5.99` in `ext_emconf.php` so TER and the Extension Manager advertise it.
- Update the stale requirements in `Documentation/Introduction/Index.rst` (`PHP ^8.1` → `^8.2`, `TYPO3 ^12.4` → `^13.4`).
- Drop two `ReflectionProperty::setAccessible()` calls in the unit tests — a no-op since PHP 8.1 and deprecated as of PHP 8.5.

Verified locally on PHP 8.5.6: `composer update` resolves cleanly (TYPO3 13.4.30, testing-framework 9.5.0); unit (50 tests) and functional (6 tests) suites pass with zero deprecations; PHPStan reports no errors and php-cs-fixer finds nothing to fix.

Closes #46