### PR TITLE
fix: AiModerationControl logger-awareness, PSR-7 response, and dead TCA token

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: pw-comments
 type: php
 docroot: public
-php_version: "8.3"
+php_version: "8.4"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"

--- a/Classes/UserFunc/TCA/AiModerationControl.php
+++ b/Classes/UserFunc/TCA/AiModerationControl.php
@@ -144,7 +144,7 @@ class AiModerationControl extends AbstractNode implements LoggerAwareInterface
         }
     }
 
-    private function getAiModerationSettings(): array
+    protected function getAiModerationSettings(): array
     {
         return Settings::getExtensionSettings();
     }

--- a/Classes/UserFunc/TCA/AiModerationControl.php
+++ b/Classes/UserFunc/TCA/AiModerationControl.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace T3\PwComments\UserFunc\TCA;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use T3\PwComments\Domain\Model\Comment;
@@ -11,6 +13,7 @@ use T3\PwComments\Domain\Repository\CommentRepository;
 use T3\PwComments\Service\Moderation\ModerationProviderFactory;
 use T3\PwComments\Utility\Settings;
 use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Log\Channel;
@@ -71,31 +74,26 @@ class AiModerationControl extends AbstractNode implements LoggerAwareInterface
     /**
      * AJAX endpoint for re-checking AI moderation
      */
-    public function recheckModeration(): void
+    public function recheckModeration(ServerRequestInterface $request): ResponseInterface
     {
-        $commentUid = (int) ($GLOBALS['TYPO3_REQUEST']->getParsedBody()['commentUid'] ?? null);
+        $commentUid = (int) ($request->getParsedBody()['commentUid'] ?? null);
 
         if (!$commentUid) {
-            $this->outputJson(['success' => false, 'message' => 'Invalid comment ID']);
-            return;
+            return new JsonResponse(['success' => false, 'message' => 'Invalid comment ID']);
         }
 
         try {
             $comment = $this->commentRepository->findByCommentUid($commentUid);
 
             if (!$comment instanceof Comment) {
-                $this->outputJson(['success' => false, 'message' => 'Comment not found']);
-                return;
+                return new JsonResponse(['success' => false, 'message' => 'Comment not found']);
             }
 
-            // Get AI moderation settings from TYPO3 configuration
             $settings = $this->getAiModerationSettings();
             if (!$settings['enableAiModeration']) {
-                $this->outputJson(['success' => false, 'message' => 'AI moderation is disabled']);
-                return;
+                return new JsonResponse(['success' => false, 'message' => 'AI moderation is disabled']);
             }
 
-            // Run AI moderation
             $moderationService = $this->moderationProviderFactory->createProvider(
                 $settings['aiModerationProvider'] ?? 'openai',
                 $settings,
@@ -103,7 +101,6 @@ class AiModerationControl extends AbstractNode implements LoggerAwareInterface
 
             $moderationResult = $moderationService->moderateComment($comment);
 
-            // Update comment with new moderation results
             if ($moderationResult->isViolation()) {
                 $comment->setAiModerationStatus('flagged');
                 $comment->setAiModerationReason($moderationResult->getReason());
@@ -124,7 +121,7 @@ class AiModerationControl extends AbstractNode implements LoggerAwareInterface
                 'confidence' => $moderationResult->getMaxScore(),
             ]);
 
-            $this->outputJson([
+            return new JsonResponse([
                 'success' => true,
                 'message' => 'AI moderation check completed',
                 'result' => [
@@ -140,7 +137,7 @@ class AiModerationControl extends AbstractNode implements LoggerAwareInterface
                 'exception' => $e,
             ]);
 
-            $this->outputJson([
+            return new JsonResponse([
                 'success' => false,
                 'message' => 'AI moderation check failed: ' . $e->getMessage(),
             ]);
@@ -149,14 +146,6 @@ class AiModerationControl extends AbstractNode implements LoggerAwareInterface
 
     private function getAiModerationSettings(): array
     {
-        // Get TypoScript settings for AI moderation
         return Settings::getExtensionSettings();
-    }
-
-    private function outputJson(array $data): void
-    {
-        header('Content-Type: application/json');
-        echo json_encode($data);
-        exit;
     }
 }

--- a/Classes/UserFunc/TCA/AiModerationControl.php
+++ b/Classes/UserFunc/TCA/AiModerationControl.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace T3\PwComments\UserFunc\TCA;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use T3\PwComments\Domain\Model\Comment;
 use T3\PwComments\Domain\Repository\CommentRepository;
 use T3\PwComments\Service\Moderation\ModerationProviderFactory;
@@ -16,8 +18,10 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 #[Channel('pw_comments')]
-class AiModerationControl extends AbstractNode
+class AiModerationControl extends AbstractNode implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     public function __construct(
         private readonly CommentRepository $commentRepository,
         private readonly ModerationProviderFactory $moderationProviderFactory,

--- a/Configuration/TCA/tx_pwcomments_domain_model_comment.php
+++ b/Configuration/TCA/tx_pwcomments_domain_model_comment.php
@@ -33,7 +33,7 @@ return [
         'iconfile' => 'EXT:pw_comments/Resources/Public/Icons/tx_pwcomments_domain_model_comment.png',
     ],
     'types' => [
-        '1' => ['showitem' => 'hidden,author,author_name,author_mail,author_website,author_ident,terms_accepted,' .
+        '1' => ['showitem' => 'hidden,author,author_name,author_mail,author_ident,terms_accepted,' .
                               'message,parent_comment,votes,rating,' .
                               '--div--;AI Moderation,ai_moderation_status,ai_moderation_reason,ai_moderation_confidence,ai_moderation_control'],
     ],

--- a/Tests/Unit/UserFunc/TCA/AiModerationControlTest.php
+++ b/Tests/Unit/UserFunc/TCA/AiModerationControlTest.php
@@ -14,10 +14,16 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
+use T3\PwComments\Domain\Model\Comment;
 use T3\PwComments\Domain\Repository\CommentRepository;
 use T3\PwComments\Service\Moderation\ModerationProviderFactory;
+use T3\PwComments\Service\Moderation\ModerationResult;
+use T3\PwComments\Service\Moderation\ModerationServiceInterface;
 use T3\PwComments\UserFunc\TCA\AiModerationControl;
+use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -274,5 +280,184 @@ final class AiModerationControlTest extends TestCase
         $this->subject->setData(['databaseRow' => ['uid' => 789]]);
 
         $this->subject->render();
+    }
+
+    #[Test]
+    public function recheckModerationReturnsErrorWhenCommentUidIsZero(): void
+    {
+        $payload = $this->decodePayload(
+            $this->subject->recheckModeration($this->buildRequest(['commentUid' => 0])),
+        );
+
+        self::assertFalse($payload['success']);
+        self::assertSame('Invalid comment ID', $payload['message']);
+    }
+
+    #[Test]
+    public function recheckModerationReturnsErrorWhenCommentUidIsMissing(): void
+    {
+        $payload = $this->decodePayload(
+            $this->subject->recheckModeration($this->buildRequest([])),
+        );
+
+        self::assertFalse($payload['success']);
+        self::assertSame('Invalid comment ID', $payload['message']);
+    }
+
+    #[Test]
+    public function recheckModerationReturnsErrorWhenCommentNotFound(): void
+    {
+        $this->commentRepository->method('findByCommentUid')->with(42)->willReturn(null);
+
+        $payload = $this->decodePayload(
+            $this->subject->recheckModeration($this->buildRequest(['commentUid' => 42])),
+        );
+
+        self::assertFalse($payload['success']);
+        self::assertSame('Comment not found', $payload['message']);
+    }
+
+    #[Test]
+    public function recheckModerationReturnsErrorWhenAiModerationDisabled(): void
+    {
+        $this->commentRepository->method('findByCommentUid')->willReturn($this->createMock(Comment::class));
+        $subject = $this->buildSubjectWithSettings(['enableAiModeration' => false]);
+
+        $payload = $this->decodePayload(
+            $subject->recheckModeration($this->buildRequest(['commentUid' => 42])),
+        );
+
+        self::assertFalse($payload['success']);
+        self::assertSame('AI moderation is disabled', $payload['message']);
+    }
+
+    #[Test]
+    public function recheckModerationApprovesNonViolatingComment(): void
+    {
+        $comment = $this->createMock(Comment::class);
+        $comment->method('getAiModerationStatus')->willReturn('approved');
+        $comment->method('getAiModerationReason')->willReturn('');
+        $comment->method('getAiModerationConfidence')->willReturn(0.1);
+        $comment->expects(self::once())->method('setAiModerationStatus')->with('approved');
+        $comment->expects(self::once())->method('setAiModerationReason')->with('');
+        $comment->expects(self::never())->method('setHidden');
+
+        $this->commentRepository->method('findByCommentUid')->willReturn($comment);
+        $this->commentRepository->expects(self::once())->method('update')->with($comment);
+        $this->persistenceManager->expects(self::once())->method('persistAll');
+        $this->logger->expects(self::once())->method('info')
+            ->with('Manual AI moderation recheck completed', self::callback(
+                static fn(array $ctx): bool => $ctx['comment_uid'] === 42 && $ctx['result'] === 'approved',
+            ));
+
+        $service = $this->createMock(ModerationServiceInterface::class);
+        $service->method('moderateComment')->willReturn(new ModerationResult(false, [], [], '', 0.1));
+        $this->moderationProviderFactory->method('createProvider')->willReturn($service);
+
+        $subject = $this->buildSubjectWithSettings([
+            'enableAiModeration' => true,
+            'aiModerationProvider' => 'openai',
+        ]);
+
+        $payload = $this->decodePayload(
+            $subject->recheckModeration($this->buildRequest(['commentUid' => 42])),
+        );
+
+        self::assertTrue($payload['success']);
+        self::assertSame('AI moderation check completed', $payload['message']);
+        self::assertSame('approved', $payload['result']['status']);
+    }
+
+    #[Test]
+    public function recheckModerationFlagsViolatingComment(): void
+    {
+        $comment = $this->createMock(Comment::class);
+        $comment->method('getAiModerationStatus')->willReturn('flagged');
+        $comment->method('getAiModerationReason')->willReturn('harassment');
+        $comment->method('getAiModerationConfidence')->willReturn(0.92);
+        $comment->expects(self::once())->method('setAiModerationStatus')->with('flagged');
+        $comment->expects(self::once())->method('setAiModerationReason')->with('harassment');
+        $comment->expects(self::once())->method('setHidden')->with(true);
+
+        $this->commentRepository->method('findByCommentUid')->willReturn($comment);
+
+        $service = $this->createMock(ModerationServiceInterface::class);
+        $service->method('moderateComment')->willReturn(
+            new ModerationResult(true, ['harassment'], ['harassment' => 0.92], 'harassment', 0.92),
+        );
+        $this->moderationProviderFactory->method('createProvider')->willReturn($service);
+
+        $subject = $this->buildSubjectWithSettings([
+            'enableAiModeration' => true,
+            'aiModerationProvider' => 'openai',
+        ]);
+
+        $payload = $this->decodePayload(
+            $subject->recheckModeration($this->buildRequest(['commentUid' => 42])),
+        );
+
+        self::assertTrue($payload['success']);
+        self::assertSame('flagged', $payload['result']['status']);
+        self::assertSame('harassment', $payload['result']['reason']);
+    }
+
+    #[Test]
+    public function recheckModerationReturnsErrorAndLogsOnProviderException(): void
+    {
+        $this->commentRepository->method('findByCommentUid')->willReturn($this->createMock(Comment::class));
+
+        $service = $this->createMock(ModerationServiceInterface::class);
+        $service->method('moderateComment')->willThrowException(new \RuntimeException('upstream down'));
+        $this->moderationProviderFactory->method('createProvider')->willReturn($service);
+
+        $this->logger->expects(self::once())->method('error')
+            ->with('Manual AI moderation recheck failed', self::callback(
+                static fn(array $ctx): bool => $ctx['comment_uid'] === 42 && $ctx['exception'] instanceof \RuntimeException,
+            ));
+
+        $subject = $this->buildSubjectWithSettings([
+            'enableAiModeration' => true,
+            'aiModerationProvider' => 'openai',
+        ]);
+
+        $response = $subject->recheckModeration($this->buildRequest(['commentUid' => 42]));
+        $payload = $this->decodePayload($response);
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertFalse($payload['success']);
+        self::assertStringContainsString('upstream down', $payload['message']);
+    }
+
+    private function buildRequest(array $parsedBody): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($parsedBody);
+        return $request;
+    }
+
+    private function decodePayload(ResponseInterface $response): array
+    {
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+        $decoded = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($decoded);
+        return $decoded;
+    }
+
+    private function buildSubjectWithSettings(array $settings): AiModerationControl
+    {
+        $subject = $this->getMockBuilder(AiModerationControl::class)
+            ->setConstructorArgs([
+                $this->commentRepository,
+                $this->moderationProviderFactory,
+                $this->persistenceManager,
+                $this->iconFactory,
+                $this->pageRenderer,
+            ])
+            ->onlyMethods(['getAiModerationSettings'])
+            ->getMock();
+        $subject->method('getAiModerationSettings')->willReturn($settings);
+        $subject->setLogger($this->logger);
+        return $subject;
     }
 }


### PR DESCRIPTION
## Summary
- Make `AiModerationControl` implement `LoggerAwareInterface` + use `LoggerAwareTrait` so the existing `#[Channel('pw_comments')]` log calls actually emit instead of silently no-opping via dynamic property promotion.
- Restructure `recheckModeration()` to take `ServerRequestInterface` and return `JsonResponse` (PSR-7) instead of `header()` + `echo` + `exit;` via a private helper. Drops the `$GLOBALS['TYPO3_REQUEST']` access in the same method. HTTP 200 preserved on all branches so the TS client UI keeps showing the friendly `message` field.
- Drop the dead `author_website` token from the comment TCA `showitem` — no DB column, no model property, no template field, no honeypot relationship (honeypot is `authorWebsite` camelCase, a request-argument check, unrelated).

Surfaces while preparing the TYPO3 v14 compatibility work (#45). Targeted at `main` first so it lands in 8.0.0; will be fast-forwarded onto `7.x` and tagged as 7.1.1.