### PR TITLE
fix: build a fresh QueryBuilder per query

### DIFF
--- a/Classes/Controller/MailNotificationController.php
+++ b/Classes/Controller/MailNotificationController.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use T3\PwComments\Utility\HashEncryptionUtility;
 use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Error\Http\ServiceUnavailableException;
 use TYPO3\CMS\Core\Exception;
@@ -28,10 +29,12 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class MailNotificationController
 {
+    private const TABLE = 'tx_pwcomments_domain_model_comment';
+
     private ServerRequestInterface $request;
 
     public function __construct(
-        private readonly QueryBuilder $queryBuilder,
+        private readonly ConnectionPool $connectionPool,
         private readonly TypoScriptService $typoScriptService,
         private readonly array $extConfig,
     ) {}
@@ -57,13 +60,16 @@ class MailNotificationController
         }
 
         // Get comment row
-        $this->queryBuilder->getRestrictions()->removeAll();
-        $row = $this->queryBuilder
+        $queryBuilder = $this->getQueryBuilder();
+        $row = $queryBuilder
             ->select('*')
-            ->from('tx_pwcomments_domain_model_comment')->where($this->queryBuilder->expr()->eq(
+            ->from(self::TABLE)
+            ->where($queryBuilder->expr()->eq(
                 'uid',
-                $this->queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
-            ))->executeQuery()->fetchAssociative();
+                $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
+            ))
+            ->executeQuery()
+            ->fetchAssociative();
 
         // Check hash
         $valid = HashEncryptionUtility::validCommentMessageHash($hash, $row['message']);
@@ -157,5 +163,17 @@ class MailNotificationController
     protected function getTypoScriptSetup(): array
     {
         return $this->request->getAttribute('frontend.typoscript')->getSetupArray();
+    }
+
+    /**
+     * Per-call QueryBuilder with no enable-field restrictions. This endpoint
+     * approves *hidden* comments for moderators, so it must always see them.
+     */
+    private function getQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder;
     }
 }

--- a/Classes/Update/MigratePluginsUpgradeWizard.php
+++ b/Classes/Update/MigratePluginsUpgradeWizard.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace T3\PwComments\Update;
 
 use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Core\Service\FlexFormService;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\ChattyInterface;
@@ -15,9 +16,11 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 #[UpgradeWizard('pwCommentsMigratePluginsWizard')]
 class MigratePluginsUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
 {
+    private const TABLE = 'tt_content';
+
     private OutputInterface $output;
 
-    public function __construct(private readonly QueryBuilder $queryBuilder, private readonly FlexFormService $flexFormService) {}
+    public function __construct(private readonly ConnectionPool $connectionPool) {}
 
     /**
      * @inheritDoc
@@ -40,14 +43,15 @@ class MigratePluginsUpgradeWizard implements UpgradeWizardInterface, ChattyInter
      */
     public function executeUpdate(): bool
     {
-        $records = $this->queryBuilder
+        $queryBuilder = $this->getQueryBuilder();
+        $records = $queryBuilder
             ->select('uid', 'list_type', 'pi_flexform')
-            ->from('tt_content')
+            ->from(self::TABLE)
             ->where(
-                $this->queryBuilder->expr()->eq('list_type', $this->queryBuilder->createNamedParameter('pwcomments_pi1')),
-                $this->queryBuilder->expr()->or(
-                    $this->queryBuilder->expr()->like('pi_flexform', $this->queryBuilder->createNamedParameter('%index%')),
-                    $this->queryBuilder->expr()->like('pi_flexform', $this->queryBuilder->createNamedParameter('%new%')),
+                $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter('pwcomments_pi1')),
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->like('pi_flexform', $queryBuilder->createNamedParameter('%index%')),
+                    $queryBuilder->expr()->like('pi_flexform', $queryBuilder->createNamedParameter('%new%')),
                 ),
             )
             ->executeQuery()
@@ -68,13 +72,13 @@ class MigratePluginsUpgradeWizard implements UpgradeWizardInterface, ChattyInter
 
             $listType = 'pwcomments_' . $plugin;
 
-            $this->queryBuilder->resetWhere();
-            $this->queryBuilder
-                ->update('tt_content')
+            $updateQb = $this->getQueryBuilder();
+            $updateQb
+                ->update(self::TABLE)
                 ->set('pi_flexform', null)
                 ->set('list_type', $listType)
                 ->where(
-                    $this->queryBuilder->expr()->eq('uid', $record['uid']),
+                    $updateQb->expr()->eq('uid', $record['uid']),
                 )
                 ->executeStatement();
             ++$updatedRecords;
@@ -90,20 +94,21 @@ class MigratePluginsUpgradeWizard implements UpgradeWizardInterface, ChattyInter
      */
     public function updateNecessary(): bool
     {
-        $count = $this->queryBuilder
+        $queryBuilder = $this->getQueryBuilder();
+        $count = $queryBuilder
             ->count('uid')
-            ->from('tt_content')
+            ->from(self::TABLE)
             ->where(
-                $this->queryBuilder->expr()->eq('list_type', $this->queryBuilder->createNamedParameter('pwcomments_pi1')),
-                $this->queryBuilder->expr()->or(
-                    $this->queryBuilder->expr()->like('pi_flexform', $this->queryBuilder->createNamedParameter('%index%')),
-                    $this->queryBuilder->expr()->like('pi_flexform', $this->queryBuilder->createNamedParameter('%new%')),
+                $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter('pwcomments_pi1')),
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->like('pi_flexform', $queryBuilder->createNamedParameter('%index%')),
+                    $queryBuilder->expr()->like('pi_flexform', $queryBuilder->createNamedParameter('%new%')),
                 ),
             )
             ->executeQuery()
-            ->columnCount();
+            ->fetchOne();
 
-        return $count > 0;
+        return (int) $count > 0;
     }
 
     /**
@@ -117,5 +122,21 @@ class MigratePluginsUpgradeWizard implements UpgradeWizardInterface, ChattyInter
     public function setOutput(OutputInterface $output): void
     {
         $this->output = $output;
+    }
+
+    /**
+     * Per-call QueryBuilder with only the deleted-row restriction. An upgrade
+     * wizard must still see hidden/disabled rows (an editor may have hidden
+     * the legacy plugin before migration), but should skip tombstones.
+     */
+    private function getQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder
+            ->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        return $queryBuilder;
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -14,22 +14,6 @@ services:
   T3\PwComments\Hooks\ProcessDatamap:
     public: true
 
-  qb.comment:
-    class: 'TYPO3\CMS\Core\Database\Query\QueryBuilder'
-    factory:
-      - '@TYPO3\CMS\Core\Database\ConnectionPool'
-      - 'getQueryBuilderForTable'
-    arguments:
-      - 'tx_pwcomments_domain_model_comment'
-
-  qb.tt_content:
-    class: 'TYPO3\CMS\Core\Database\Query\QueryBuilder'
-    factory:
-      - '@TYPO3\CMS\Core\Database\ConnectionPool'
-      - 'getQueryBuilderForTable'
-    arguments:
-      - 'tx_pwcomments_domain_model_comment'
-
   pw_comments.extension_config:
     class: array
     factory:
@@ -40,14 +24,9 @@ services:
 
   T3\PwComments\Controller\MailNotificationController:
     arguments:
-      $queryBuilder: '@qb.comment'
       $extConfig: '@pw_comments.extension_config'
 
   TYPO3\CMS\Core\Localization\LanguageService:
     factory:
       - '@TYPO3\CMS\Core\Localization\LanguageServiceFactory'
       - 'create'
-
-  T3\PwComments\Update\MigratePluginsUpgradeWizard:
-    arguments:
-      $queryBuilder: '@qb.tt_content'

--- a/Tests/Fixtures/Database/tt_content_pwcomments_legacy.csv
+++ b/Tests/Fixtures/Database/tt_content_pwcomments_legacy.csv
@@ -1,0 +1,27 @@
+tt_content
+,uid,pid,CType,list_type,pi_flexform
+,10,1,list,pwcomments_pi1,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?>
+<T3FlexForms>
+    <data>
+        <sheet index=""sDEF"">
+            <language index=""lDEF"">
+                <field index=""switchableControllerActions"">
+                    <value index=""vDEF"">Comment-&gt;index;Comment-&gt;upvote;Comment-&gt;downvote</value>
+                </field>
+            </language>
+        </sheet>
+    </data>
+</T3FlexForms>"
+,11,1,list,pwcomments_pi1,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?>
+<T3FlexForms>
+    <data>
+        <sheet index=""sDEF"">
+            <language index=""lDEF"">
+                <field index=""switchableControllerActions"">
+                    <value index=""vDEF"">Comment-&gt;new;Comment-&gt;create;Comment-&gt;confirmComment</value>
+                </field>
+            </language>
+        </sheet>
+    </data>
+</T3FlexForms>"
+,12,1,text,,

--- a/Tests/Functional/Update/MigratePluginsUpgradeWizardTest.php
+++ b/Tests/Functional/Update/MigratePluginsUpgradeWizardTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3\PwComments\Tests\Functional\Update;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\NullOutput;
+use T3\PwComments\Update\MigratePluginsUpgradeWizard;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional test for {@see MigratePluginsUpgradeWizard}.
+ *
+ * Regression for issue #36 / #52: the wizard previously held a single,
+ * DI-injected QueryBuilder across its select/update calls and reset it via
+ * the removed `resetQueryParts()` API, which crashed `upgrade:run`. The
+ * wizard now must build a fresh QueryBuilder per query and rewrite legacy
+ * `pwcomments_pi1` rows to the split `pwcomments_show`/`pwcomments_new`
+ * plugins (and null out the flexform that drove the old switchable actions).
+ */
+final class MigratePluginsUpgradeWizardTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'install',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/pw_comments',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // tt_content.list_type was removed in TYPO3 v14. The wizard targets
+        // pre-v7 records that still carry list_type='pwcomments_pi1' and a
+        // flexform with switchableControllerActions — both gone on v14, where
+        // T3PwCommentsCTypeMigration supersedes this wizard.
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 14) {
+            self::markTestSkipped('MigratePluginsUpgradeWizard is only meaningful on TYPO3 v13 (tt_content.list_type removed in v14).');
+        }
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/Database/tt_content_pwcomments_legacy.csv');
+    }
+
+    #[Test]
+    public function updateNecessaryReturnsTrueWhenLegacyRowsExist(): void
+    {
+        self::assertTrue($this->buildWizard()->updateNecessary());
+    }
+
+    #[Test]
+    public function executeUpdateMigratesLegacyRowsToSplitPlugins(): void
+    {
+        $wizard = $this->buildWizard();
+
+        self::assertTrue($wizard->executeUpdate());
+
+        $indexRow = $this->fetchRow(10);
+        self::assertSame('pwcomments_show', $indexRow['list_type']);
+        self::assertNull($indexRow['pi_flexform']);
+
+        $newRow = $this->fetchRow(11);
+        self::assertSame('pwcomments_new', $newRow['list_type']);
+        self::assertNull($newRow['pi_flexform']);
+
+        $untouched = $this->fetchRow(12);
+        self::assertSame('text', $untouched['CType']);
+    }
+
+    #[Test]
+    public function updateNecessaryReturnsFalseAfterMigration(): void
+    {
+        $wizard = $this->buildWizard();
+        $wizard->executeUpdate();
+
+        self::assertFalse($this->buildWizard()->updateNecessary());
+    }
+
+    private function buildWizard(): MigratePluginsUpgradeWizard
+    {
+        $wizard = $this->get(MigratePluginsUpgradeWizard::class);
+        $wizard->setOutput(new NullOutput());
+
+        return $wizard;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchRow(int $uid): array
+    {
+        $qb = $this->getConnectionPool()->getQueryBuilderForTable('tt_content');
+        $qb->getRestrictions()->removeAll();
+
+        $row = $qb
+            ->select('uid', 'CType', 'list_type', 'pi_flexform')
+            ->from('tt_content')
+            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
+            ->executeQuery()
+            ->fetchAssociative();
+
+        self::assertIsArray($row, sprintf('Expected tt_content row uid=%d to exist.', $uid));
+        return $row;
+    }
+}

--- a/Tests/Unit/Controller/MailNotificationControllerTest.php
+++ b/Tests/Unit/Controller/MailNotificationControllerTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3\PwComments\Tests\Unit\Controller;
+
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use T3\PwComments\Controller\MailNotificationController;
+use T3\PwComments\Utility\HashEncryptionUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+
+final class MailNotificationControllerTest extends TestCase
+{
+    private const ENCRYPTION_KEY = 'test-encryption-key';
+    private const COMMENT_MESSAGE = 'Hello world';
+
+    private ?string $encryptionKeyBackup = null;
+
+    protected function setUp(): void
+    {
+        $this->encryptionKeyBackup = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = self::ENCRYPTION_KEY;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->encryptionKeyBackup === null) {
+            unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']);
+        } else {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $this->encryptionKeyBackup;
+        }
+    }
+
+    #[Test]
+    public function sendMailThrowsInvalidArgumentExceptionWhenActionIsMissing(): void
+    {
+        $controller = $this->buildController($this->buildQueryBuilder(null, expectRemoveAll: false));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(5066963646);
+
+        $controller->sendMail($this->buildRequest([
+            'action' => '',
+            'hash' => 'abc',
+            'uid' => 1,
+            'pid' => 1,
+        ]));
+    }
+
+    #[Test]
+    public function sendMailThrowsInvalidArgumentExceptionWhenUidIsZero(): void
+    {
+        $controller = $this->buildController($this->buildQueryBuilder(null, expectRemoveAll: false));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(5066963646);
+
+        $controller->sendMail($this->buildRequest([
+            'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+            'hash' => 'abc',
+            'uid' => 0,
+            'pid' => 1,
+        ]));
+    }
+
+    #[Test]
+    public function sendMailThrowsInvalidArgumentExceptionWhenPidIsZero(): void
+    {
+        $controller = $this->buildController($this->buildQueryBuilder(null, expectRemoveAll: false));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(5066963646);
+
+        $controller->sendMail($this->buildRequest([
+            'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+            'hash' => 'abc',
+            'uid' => 1,
+            'pid' => 0,
+        ]));
+    }
+
+    #[Test]
+    public function sendMailThrowsInvalidArgumentExceptionWhenHashIsMissing(): void
+    {
+        $controller = $this->buildController($this->buildQueryBuilder(null, expectRemoveAll: false));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(5066963646);
+
+        $controller->sendMail($this->buildRequest([
+            'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+            'hash' => '',
+            'uid' => 1,
+            'pid' => 1,
+        ]));
+    }
+
+    #[Test]
+    public function sendMailThrowsInvalidArgumentExceptionWhenTxPwcommentsKeyIsAbsent(): void
+    {
+        // sendMail does `$queryParams['tx_pwcomments'] ?? []`, so a request without that key
+        // produces an empty params array. Accessing $params['action'] / ['hash'] then triggers
+        // PHP 8 "undefined array key" warnings before the InvalidArgumentException fires.
+        // Suppress the warnings and pin the current contract.
+        $controller = $this->buildController($this->buildQueryBuilder(null, expectRemoveAll: false));
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([]);
+
+        set_error_handler(static fn() => true, \E_WARNING);
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionCode(5066963646);
+            $controller->sendMail($request);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    #[Test]
+    public function sendMailThrowsTypeErrorWhenCommentRowIsNotFound(): void
+    {
+        // fetchAssociative() returning false makes $row['message'] resolve to null (with a
+        // warning), which the strict-typed HashEncryptionUtility::validCommentMessageHash
+        // rejects with a TypeError. Pinned as the current contract.
+        $controller = $this->buildController($this->buildQueryBuilder(false));
+
+        set_error_handler(static fn() => true, \E_WARNING);
+        try {
+            $this->expectException(\TypeError::class);
+            $controller->sendMail($this->buildRequest([
+                'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+                'hash' => 'whatever',
+                'uid' => 1,
+                'pid' => 1,
+            ]));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    #[Test]
+    public function sendMailThrowsRuntimeExceptionWhenHashDoesNotMatch(): void
+    {
+        $controller = $this->buildController($this->buildQueryBuilder([
+            'uid' => 1,
+            'message' => self::COMMENT_MESSAGE,
+            'hidden' => 1,
+        ]));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(9298443636);
+
+        $controller->sendMail($this->buildRequest([
+            'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+            'hash' => 'this-is-not-the-real-hash',
+            'uid' => 1,
+            'pid' => 1,
+        ]));
+    }
+
+    #[Test]
+    public function sendMailReturns200AndInvokesExtbaseControllerWhenActionMatchesAndCommentHidden(): void
+    {
+        $controller = $this->buildController(
+            $this->buildQueryBuilder([
+                'uid' => 42,
+                'message' => self::COMMENT_MESSAGE,
+                'hidden' => 1,
+            ]),
+        );
+
+        $response = $controller->sendMail($this->buildRequest([
+            'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+            'hash' => HashEncryptionUtility::createHashForCommentMessage(self::COMMENT_MESSAGE),
+            'uid' => 42,
+            'pid' => 1,
+        ]));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(
+            [
+                'extensionName' => 'PwComments',
+                'controller' => 'Comment',
+                'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+                'pluginName' => 'Pi2',
+                'settings' => ['_commentUid' => 42, '_skipMakingSettingsRenderable' => true],
+            ],
+            $controller->extbaseInvocations[0] ?? null,
+        );
+    }
+
+    #[Test]
+    public function sendMailReturns400WhenActionMatchesButCommentIsNotHidden(): void
+    {
+        $controller = $this->buildController(
+            $this->buildQueryBuilder([
+                'uid' => 7,
+                'message' => self::COMMENT_MESSAGE,
+                'hidden' => 0,
+            ]),
+        );
+
+        $response = $controller->sendMail($this->buildRequest([
+            'action' => 'sendAuthorMailWhenCommentHasBeenApproved',
+            'hash' => HashEncryptionUtility::createHashForCommentMessage(self::COMMENT_MESSAGE),
+            'uid' => 7,
+            'pid' => 1,
+        ]));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame([], $controller->extbaseInvocations);
+    }
+
+    #[Test]
+    public function sendMailReturns400WhenActionIsUnknownEvenIfCommentIsHidden(): void
+    {
+        $controller = $this->buildController(
+            $this->buildQueryBuilder([
+                'uid' => 7,
+                'message' => self::COMMENT_MESSAGE,
+                'hidden' => 1,
+            ]),
+        );
+
+        $response = $controller->sendMail($this->buildRequest([
+            'action' => 'someUnknownAction',
+            'hash' => HashEncryptionUtility::createHashForCommentMessage(self::COMMENT_MESSAGE),
+            'uid' => 7,
+            'pid' => 1,
+        ]));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame([], $controller->extbaseInvocations);
+    }
+
+    private function buildController(QueryBuilder $queryBuilder): MailNotificationController
+    {
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')
+            ->with('tx_pwcomments_domain_model_comment')
+            ->willReturn($queryBuilder);
+
+        return new class ($connectionPool, $this->createMock(TypoScriptService::class), []) extends MailNotificationController {
+            public array $extbaseInvocations = [];
+
+            protected function runExtbaseController(
+                $extensionName,
+                $controller,
+                $action = 'index',
+                $pluginName = 'show',
+                $settings = [],
+                $vendorName = 'T3',
+            ) {
+                $this->extbaseInvocations[] = [
+                    'extensionName' => $extensionName,
+                    'controller' => $controller,
+                    'action' => $action,
+                    'pluginName' => $pluginName,
+                    'settings' => $settings,
+                ];
+                return '';
+            }
+        };
+    }
+
+    private function buildRequest(array $txPwcomments): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['tx_pwcomments' => $txPwcomments]);
+        return $request;
+    }
+
+    private function buildQueryBuilder(array|false|null $row, bool $expectRemoveAll = true): QueryBuilder&MockObject
+    {
+        $restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
+        $restrictions->expects($expectRemoveAll ? self::once() : self::never())->method('removeAll');
+
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('uid = :uid');
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn($row ?? false);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn(':uid');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        return $queryBuilder;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #52. Fixes #36.

- `MailNotificationController` and `MigratePluginsUpgradeWizard` now inject `ConnectionPool` and build a fresh `QueryBuilder` per query via `getQueryBuilderForTable()`. The TYPO3 docs explicitly warn against DI-injecting a single `QueryBuilder` — it carries state, which was the crash mode in #36.
- Drops the `qb.comment` / `qb.tt_content` factory aliases from `Services.yaml`. The latter was silently pointing at `tx_pwcomments_domain_model_comment` instead of `tt_content`.
- Drops the unused `FlexFormService` constructor arg from the wizard.
- Fixes `updateNecessary()` to use `fetchOne()` instead of `columnCount()`; the previous call always returned 1 for the `COUNT(uid)` query, so the gate always reported work to do.
- Adds a functional test for the wizard end-to-end (none existed). The test is gated to TYPO3 v13 because `tt_content.list_type` was removed in v14, where `T3PwCommentsCTypeMigration` supersedes this wizard.